### PR TITLE
arangodb grouping

### DIFF
--- a/pkg/db/common/tasks.go
+++ b/pkg/db/common/tasks.go
@@ -49,7 +49,8 @@ func CreateTaskFilter(pageIdx int, pageSize int, sort string, sortOrder string) 
 	if f.PageIndex < 0 {
 		f.PageIndex = 0
 	}
-	if f.PageSize == 0 {
+
+	if f.PageSize <= 0 || f.PageSize >= 50 {
 		f.PageSize = 10
 	}
 

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -142,11 +142,12 @@ type DatabaseDriver interface {
 	GetTaskArtefacts(id string) ([]artefact.Artefact, error)
 	ListTasks() []dbcommon.DocItem
 	AllTasks(config *setting.Config) []agenttasks.Task
-	AllTasksFiltered(config *setting.Config, f dbcommon.TaskFilter) dbcommon.TaskResult
+	AllTasksFiltered(config *setting.Config, f dbcommon.TaskFilter) (dbcommon.TaskResult, error)
 	AllUserTask(config *setting.Config, id string) ([]agenttasks.Task, error)
 	AllUserFiltered(config *setting.Config, id string, f dbcommon.TaskFilter) (dbcommon.TaskResult, error)
 	AllNodeTask(config *setting.Config, id string) ([]agenttasks.Task, error)
 	GetTaskByStatus(*setting.Config, string) ([]agenttasks.Task, error)
+	GetTaskMetrics() (map[string]interface{}, error)
 
 	// Token
 	InsertToken(t *token.Token) (string, error)

--- a/pkg/db/tiedot/task.go
+++ b/pkg/db/tiedot/task.go
@@ -175,12 +175,8 @@ func (d *Database) AllTasks(config *setting.Config) []agenttasks.Task {
 	return tasks_id
 }
 
-// not implemented
-func (d *Database) AllTasksFiltered(config *setting.Config, f dbcommon.TaskFilter) dbcommon.TaskResult {
-	return dbcommon.TaskResult{
-		Total: 0,
-		Tasks: d.AllTasks(config),
-	}
+func (d *Database) AllTasksFiltered(config *setting.Config, f dbcommon.TaskFilter) (dbcommon.TaskResult, error) {
+	return dbcommon.TaskResult{}, errors.New("no implemented")
 }
 
 func (d *Database) AllNodeTask(config *setting.Config, id string) ([]agenttasks.Task, error) {
@@ -221,11 +217,10 @@ func (d *Database) AllUserTask(config *setting.Config, id string) ([]agenttasks.
 	return res, nil
 }
 
-// not implemented
 func (d *Database) AllUserFiltered(config *setting.Config, id string, f dbcommon.TaskFilter) (dbcommon.TaskResult, error) {
-	c, err := d.AllUserTask(config, id)
-	return dbcommon.TaskResult{
-		Total: 0,
-		Tasks: c,
-	}, err
+	return dbcommon.TaskResult{}, errors.New("no implemented")
+}
+
+func (d *Database) GetTaskMetrics() (map[string]interface{}, error) {
+	return nil, errors.New("no implemented")
 }

--- a/routes/api/client/dashboard/dashboard.go
+++ b/routes/api/client/dashboard/dashboard.go
@@ -29,66 +29,12 @@ import (
 	"gopkg.in/macaron.v1"
 )
 
-type DashboardData struct {
-	Total    int `json:"total"`
-	Running  int `json:"running"`
-	Waiting  int `json:"waiting"`
-	Error    int `json:"error"`
-	Failed   int `json:"failed"`
-	Success  int `json:"success"`
-	Stopped  int `json:"stopped"`
-	Stopping int `json:"stopping"`
-}
-
 func Stats(ctx *macaron.Context, db *database.Database) error {
-	rtasks, e := db.Driver.GetTaskByStatus(db.Config, "running")
+	statuses, e := db.Driver.GetTaskMetrics()
 	if e != nil {
 		return e
 	}
-	running_tasks := len(rtasks)
-	wtasks, e := db.Driver.GetTaskByStatus(db.Config, "waiting")
-	if e != nil {
-		return e
-	}
-	waiting_tasks := len(wtasks)
-	etasks, e := db.Driver.GetTaskByStatus(db.Config, "error")
-	if e != nil {
-		return e
-	}
-	error_tasks := len(etasks)
-	ftasks, e := db.Driver.GetTaskByStatus(db.Config, "failed")
-	if e != nil {
-		return e
-	}
-	failed_tasks := len(ftasks)
-	stasks, e := db.Driver.GetTaskByStatus(db.Config, "success")
-	if e != nil {
-		return e
-	}
-	succeeded_tasks := len(stasks)
-	stoppedtasks, e := db.Driver.GetTaskByStatus(db.Config, "stopped")
-	if e != nil {
-		return e
-	}
-	stopped_tasks := len(stoppedtasks)
-
-	instoptasks, e := db.Driver.GetTaskByStatus(db.Config, "stop")
-	if e != nil {
-		return e
-	}
-	instop_tasks := len(instoptasks)
-
-	p := DashboardData{
-		len(db.Driver.ListDocs("Tasks")),
-		running_tasks,
-		waiting_tasks,
-		error_tasks,
-		failed_tasks,
-		succeeded_tasks,
-		stopped_tasks,
-		instop_tasks,
-	}
-	ctx.JSON(200, &p)
+	ctx.JSON(200, &statuses)
 	return nil
 }
 

--- a/routes/api/tasks/show.go
+++ b/routes/api/tasks/show.go
@@ -157,7 +157,7 @@ func AllFiltered(ctx *context.Context, db *database.Database) (result dbcommon.T
 
 	if ctx.IsLogged {
 		if ctx.User.IsAdmin() {
-			result = db.Driver.AllTasksFiltered(db.Config, f)
+			result, _ = db.Driver.AllTasksFiltered(db.Config, f)
 		} else {
 			result, _ = db.Driver.AllUserFiltered(db.Config, ctx.User.ID, f)
 		}


### PR DESCRIPTION
- Use COLLECT query to get task status counts instead of retrieving all tasks and counting length server-side